### PR TITLE
7 blankmissing variable attributes

### DIFF
--- a/create_netcdf.py
+++ b/create_netcdf.py
@@ -117,13 +117,15 @@ def add_variables(ncfile, instrument_dict, product):
                         mdatvalue = np.array(newmdatvalue, dtype = np.int8)
                     # print warning for example values, and don't add example values for standard_name
                     if mdatkey == 'standard_name' and ('EXAMPLE' in mdatvalue or mdatvalue == ''):
-                        print(f"WARN: No standard name for variable {key}")
+                        print(f"WARN: No standard name for variable {key}, standard_name attribute not added")
                     elif 'EXAMPLE' in mdatvalue:
                         print(f"WARN: example value for attribute {mdatkey} for variable {key}")
                     # don't add EXAMPLE standard name
                     if not (mdatkey == 'standard_name' and 'EXAMPLE' in mdatvalue):
                         # don't add empty attributes
-                        if not isinstance(mdatvalue, str) or mdatvalue != '':
+                        if mdatvalue == '':
+                            print(f"WARN: No value for attribute {mdatkey} for variable {key}, attribute not added")
+                        else:
                             var.setncattr(mdatkey, mdatvalue)
     
 

--- a/create_netcdf.py
+++ b/create_netcdf.py
@@ -115,9 +115,17 @@ def add_variables(ncfile, instrument_dict, product):
                         newmdatvalue = [ int(i.strip('b')) for i in mdatvalue.split(',') ]
                         # turn list into array with int8 type 
                         mdatvalue = np.array(newmdatvalue, dtype = np.int8)
-                    # don't add empty attributes
-                    if not isinstance(mdatvalue, str) or mdatvalue != '':
-                        var.setncattr(mdatkey, mdatvalue)
+                    # print warning for example values, and don't add example values for standard_name
+                    if 'EXAMPLE' in mdatvalue:
+                        if mdatkey == 'standard_name':
+                            print(f"WARN: No standard name for variable {key}")
+                        else:
+                            print(f"WARN: example value for attribute {mdatkey} for variable {key}")
+                    # don't add EXAMPLE standard name
+                    if not (mdatkey == 'standard_name' and 'EXAMPLE' in mdatvalue):
+                        # don't add empty attributes
+                        if not isinstance(mdatvalue, str) or mdatvalue != '':
+                            var.setncattr(mdatkey, mdatvalue)
     
 
             

--- a/create_netcdf.py
+++ b/create_netcdf.py
@@ -121,7 +121,7 @@ def add_variables(ncfile, instrument_dict, product):
                     elif 'EXAMPLE' in mdatvalue:
                         print(f"WARN: example value for attribute {mdatkey} for variable {key}")
                     # don't add EXAMPLE standard name
-                    if not (mdatkey == 'standard_name' and 'EXAMPLE' in mdatvalue):
+                    if not (mdatkey == 'standard_name' and ('EXAMPLE' in mdatvalue or mdatvalue == '')):
                         # don't add empty attributes
                         if mdatvalue == '':
                             print(f"WARN: No value for attribute {mdatkey} for variable {key}, attribute not added")

--- a/create_netcdf.py
+++ b/create_netcdf.py
@@ -116,11 +116,10 @@ def add_variables(ncfile, instrument_dict, product):
                         # turn list into array with int8 type 
                         mdatvalue = np.array(newmdatvalue, dtype = np.int8)
                     # print warning for example values, and don't add example values for standard_name
-                    if 'EXAMPLE' in mdatvalue:
-                        if mdatkey == 'standard_name':
-                            print(f"WARN: No standard name for variable {key}")
-                        else:
-                            print(f"WARN: example value for attribute {mdatkey} for variable {key}")
+                    if mdatkey == 'standard_name' and ('EXAMPLE' in mdatvalue or mdatvalue == ''):
+                        print(f"WARN: No standard name for variable {key}")
+                    elif 'EXAMPLE' in mdatvalue:
+                        print(f"WARN: example value for attribute {mdatkey} for variable {key}")
                     # don't add EXAMPLE standard name
                     if not (mdatkey == 'standard_name' and 'EXAMPLE' in mdatvalue):
                         # don't add empty attributes

--- a/tsv2dict.py
+++ b/tsv2dict.py
@@ -28,7 +28,10 @@ def tsv2dict_vars(tsv_file):
             current_var_dict = {}
             #continue
         if current_line['Attribute'] != '':
-            current_var_dict[current_line['Attribute']] = current_line['Value']
+            if current_line['Value'] == '' and 'example value' in current_line.keys() and current_line['example value'] != '':
+                current_var_dict[current_line['Attribute']] = f"EXAMPLE: {current_line['example value']}"
+            else:
+                current_var_dict[current_line['Attribute']] = current_line['Value']
     all_vars_dict[current_var] = current_var_dict
     
     return all_vars_dict


### PR DESCRIPTION
Addresses some issues in #7 
1. Not added any `proposed_standard_name`. New standard names are proposed through GitHub, I haven't found a way to read through GitHub issues in python to check proposals.
2. If the value of an attribute is empty but an example value is given, then the example value is read but appended with "EXAMPLE" (in `tsv2dict.py`, function `tsv2dict_vars`). This leads to a warning being printed out to alert user (function `add_variables` in `create_netcdf.py`). Exception for attribute `standard_name`, warning is printed but attritbute not added.
3. Empty attribute values trigger warning print out, attribute not added.