### PR TITLE
Change in running tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,10 +1,12 @@
 name: build
 
 on:
-  push:
+  pull_request:
     branches:
       - main
-  pull_request:
+  schedule:
+    # midnight Sunday
+    - cron: '0 0 * * 0'
 
 jobs:
   build:


### PR DESCRIPTION
Added running tests on weekly cron
* help catch if dependencies change and break something

Don't run tests on push to main
* as main is protected and we're not pushing directly to it anyway, this became redundant