### PR TITLE
Check variable attribute value is string before comparing it to a string

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ['3.7.16', '3.8', '3.9', '3.10', '3.11']
         exclude:
           - os: windows-latest
-            python-version: '3.7'
+            python-version: '3.7.16'
       fail-fast: false
 
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7.16', '3.8', '3.9', '3.10', '3.11']
         exclude:
           - os: windows-latest
             python-version: '3.7'

--- a/src/ncas_amof_netcdf_template/create_netcdf.py
+++ b/src/ncas_amof_netcdf_template/create_netcdf.py
@@ -179,7 +179,11 @@ def add_variables(ncfile, instrument_dict, product, verbose=0):
                         and ("EXAMPLE" in mdatvalue or mdatvalue == "")
                     ):
                         # don't add empty attributes
-                        if mdatvalue == "" and verbose >= 1:
+                        if (
+                            isinstance(mdatvalue, str)
+                            and mdatvalue == ""
+                            and verbose >= 1
+                        ):
                             print(
                                 f"WARN: No value for attribute {mdatkey} "
                                 "for variable {key}, attribute not added"


### PR DESCRIPTION
Closes issue #92, where an array was being compared to a string. Previously, numpy threw a warning, but from v1.25 this now causes an error. The value of the variable attribute is now checked to see if it is a string (which all are at this stage except for the flag_values), before the string is checked to see if it is empty.