### PR TITLE
Return day-of-year variable as list

### DIFF
--- a/src/ncas_amof_netcdf_template/util.py
+++ b/src/ncas_amof_netcdf_template/util.py
@@ -119,7 +119,7 @@ def get_times(dt_times):
     ]
     time_coverage_start_dt = unix_times[0]
     time_coverage_end_dt = unix_times[-1]
-    doy = (
+    doy = list(
         np.array(doy)
         + np.array([i / 24 for i in hours])
         + np.array([i / (24 * 60) for i in minutes])


### PR DESCRIPTION
Day-of-year (doy) variable was being returned as an array, rather than a list. This caused problems when doing operations on, or joining together, multiple `get_times` returns - different functions would be needed for doy compared to other time variables (e.g. minutes). Opted to return doy as a list to be in line with other variables.