### PR TITLE
Fixing Codecov

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -31,7 +31,8 @@ jobs:
         pip install .
     - name: Test with pytest
       run: >
-        python -m pytest --cov -v tests/test_build.py tests/test_create_netcdf.py
-        tests/test_util.py tests/test_values.py tests/test_tsv2dict.py
+        python -m pytest --cov-report term --cov -v tests/test_build.py
+        tests/test_create_netcdf.py tests/test_util.py tests/test_values.py
+        tests/test_tsv2dict.py
     - name: Upload coverage reports to Codecov with GitHub Action
       uses: codecov/codecov-action@v3


### PR DESCRIPTION
`pytest --cov` was not printing out coverage stats for `src`, for some reason, and as such Codecov reporting was incorrect. Trying to fix that here.