### PR TITLE
Define QC flag values and meanings

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -42,4 +42,4 @@ jobs:
       if: ${{ matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' }}
       uses: codecov/codecov-action@v4.2.0
       env:
-        CODECOV_TOKEN: ${{ secrects.CODECOV_TOKEN }}
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -39,4 +39,6 @@ jobs:
         tests/test_create_netcdf.py tests/test_util.py tests/test_values.py
         tests/test_tsv2dict.py
     - name: Upload coverage reports to Codecov with GitHub Action
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4.2.0
+      env:
+        CODECOV_TOKEN: ${{ secrects.CODECOV_TOKEN }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,8 +14,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest-large, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        exclude:
+          - os: macos-latest
+            python-version: '3.8'
       fail-fast: false
 
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest-large, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
       fail-fast: false
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -39,6 +39,7 @@ jobs:
         tests/test_create_netcdf.py tests/test_util.py tests/test_values.py
         tests/test_tsv2dict.py
     - name: Upload coverage reports to Codecov with GitHub Action
+      if: ${{ matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' }}
       uses: codecov/codecov-action@v4.2.0
       env:
         CODECOV_TOKEN: ${{ secrects.CODECOV_TOKEN }}

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -134,6 +134,8 @@ Quality Control Flag Data
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 Quality control flags in the NCAS-GENERAL standard use flag_values and flag_meanings to convey the quality of the data. When adding data to a quality control variable, an error is raised if that data includes values not in the flag_values attribute.
 
+The flag_values and flag_meanings used in the quality control variables by default are those defined in the data product spreadsheets, but the NCAS-General standard allows any flag meanings and values to be used, provided the first two meanings are "not_used" and "good_data", and the first two values are 0 and 1. The `change_qc_flags <util.html#ncas_amof_netcdf_template.util.change_qc_flags>`_ function provides a way to change the default values.
+
 Time
 ----
 netCDF files that follow the NCAS-GENERAL metadata standard require a number of variables that correspond to time, or a portion of it, including (but not limited to) UNIX time, year, month and day.

--- a/src/ncas_amof_netcdf_template/util.py
+++ b/src/ncas_amof_netcdf_template/util.py
@@ -10,6 +10,7 @@ import warnings
 import json
 import yaml
 import xml.etree.ElementTree as ET
+import warnings
 
 
 def _map_data_type(data_type):
@@ -353,6 +354,62 @@ def get_times(dt_times):
         time_coverage_end_dt,
         file_date,
     )
+
+
+def change_qc_flags(ncfile, ncfile_varname, flag_meanings=[], flag_values=None):
+    """
+    Change the flag meanings and flag values in a quality control variable from
+    the default options. The first two flag meanings must be "not_used" and
+    "good_data", and all spaces in flag meanings will be replaced with underscores.
+    If given, the first two flag values must be 0 and 1. If not given, flag values
+    will be worked out based on the number of flag meanings and will be sequential
+    values.
+
+    Args:
+        ncfile (netCDF Dataset): Dataset object of netCDF file.
+        ncfile_varname (str): Name of variable in netCDF file.
+        flag_meanings (list): List of flag meanings to be used in variable.
+        flag_values (list): List of integer flag values to be used in variable. Will
+                            be automatically worked out if not provided.
+    """
+    if ncfile_varname not in ncfile.variables.keys():
+        msg = f"Variable {ncfile_varname} not in netCDF file"
+        raise ValueError(msg)
+
+    for i, meaning in enumerate(flag_meanings):
+        if " " in meaning:
+            msg = f"Space found in flag meaning '{meaning}', changing to underscore."
+            warnings.warn(msg)
+            flag_meanings[i] = meaning.replace(" ", "_")
+
+    if flag_meanings[0] != "not_used" or flag_meanings[1] != "good_data":
+        msg = (
+            "Invalid flag meanings - first two flag meanings must be 'not_used' "
+            f"and 'good_data', not '{flag_meanings[0]}' and '{flag_meanings[1]}'."
+        )
+        raise ValueError(msg)
+
+    if flag_values:
+        if flag_values[0] != 0 or flag_values[1] != 1:
+            msg = (
+                "Invalid flag values - first two flag values must be 0 and 1, "
+                f"not {flag_values[0]} and {flag_values[1]}."
+            )
+            raise ValueError(msg)
+        if len(flag_values) != len(flag_meanings):
+            msg = (
+                f"Different number of flag_values ({len(flag_values)}) "
+                f"and flag_meanings ({len(flag_meanings)})."
+            )
+            raise ValueError(msg)
+    else:
+        flag_values = list(range(len(flag_meanings)))
+
+    var_type = ncfile[ncfile_varname].dtype
+    flag_value_array = np.array(flag_values, dtype=var_type)
+
+    ncfile[ncfile_varname].setncattr("flag_values", flag_value_array)
+    ncfile[ncfile_varname].setncattr("flag_meanings", " ".join(flag_meanings))
 
 
 def update_variable(ncfile, ncfile_varname, data, qc_data_error=True):

--- a/src/ncas_amof_netcdf_template/util.py
+++ b/src/ncas_amof_netcdf_template/util.py
@@ -10,7 +10,6 @@ import warnings
 import json
 import yaml
 import xml.etree.ElementTree as ET
-import warnings
 
 
 def _map_data_type(data_type):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -227,7 +227,6 @@ def test_change_qc_flags():
         var = ncfile.createVariable("qc_var", "i4", ("dim",))
         var.flag_values = [0, 1, 2]
         var.flag_meanings = "not_used good_data suspect_data"
-        temp_path = temp.name
 
     # test error raised when invalid variable name given
     with pytest.raises(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -219,6 +219,111 @@ def test_get_times_with_incompatible_dates():
         util.get_times(dt_times)
 
 
+def test_change_qc_flags():
+    # Create a temporary netCDF file
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".nc") as temp:
+        ncfile = Dataset(temp.name, "w", format="NETCDF4")
+        ncfile.createDimension("dim", 3)
+        var = ncfile.createVariable("qc_var", "i4", ("dim",))
+        var.flag_values = [0, 1, 2]
+        var.flag_meanings = "not_used good_data suspect_data"
+        temp_path = temp.name
+
+    # test error raised when invalid variable name given
+    with pytest.raises(
+        ValueError,
+        match=r"Variable qc_flag not in netCDF file",
+    ):
+        util.change_qc_flags(ncfile, "qc_flag")
+
+    # test warning on space in flag_meanings but then correctly converted
+    flag_meanings = ["not used", "good_data", "strange_data"]
+    with pytest.warns(
+        UserWarning,
+        match=r"Space found in flag meaning 'not used', changing to underscore.",
+    ):
+        util.change_qc_flags(ncfile, "qc_var", flag_meanings=flag_meanings)
+    assert (
+        ncfile["qc_var"].getncattr("flag_meanings") == "not_used good_data strange_data"
+    )
+
+    # test error raised when not_used is not first meaning
+    flag_meanings = ["wrong_meaning", "good_data", "suspect_data"]
+    with pytest.raises(
+        ValueError,
+        match=r"Invalid flag meanings - first two flag meanings must be 'not_used' and 'good_data', not 'wrong_meaning' and 'good_data'.",
+    ):
+        util.change_qc_flags(ncfile, "qc_var", flag_meanings=flag_meanings)
+
+    # test error raised when good_data is not second meaning
+    flag_meanings = ["not_used", "wrong_meaning", "suspect_data"]
+    with pytest.raises(
+        ValueError,
+        match=r"Invalid flag meanings - first two flag meanings must be 'not_used' and 'good_data', not 'not_used' and 'wrong_meaning'.",
+    ):
+        util.change_qc_flags(ncfile, "qc_var", flag_meanings=flag_meanings)
+
+    # test error raised when 0 is not first value
+    flag_meanings = ["not_used", "good_data", "suspect_data"]
+    flag_values = [3, 1, 2]
+    with pytest.raises(
+        ValueError,
+        match=r"Invalid flag values - first two flag values must be 0 and 1, not 3 and 1.",
+    ):
+        util.change_qc_flags(
+            ncfile, "qc_var", flag_meanings=flag_meanings, flag_values=flag_values
+        )
+
+    # test error raised when 1 is not second value
+    flag_meanings = ["not_used", "good_data", "suspect_data"]
+    flag_values = [0, 3, 2]
+    with pytest.raises(
+        ValueError,
+        match=r"Invalid flag values - first two flag values must be 0 and 1, not 0 and 3.",
+    ):
+        util.change_qc_flags(
+            ncfile, "qc_var", flag_meanings=flag_meanings, flag_values=flag_values
+        )
+
+    # test error raised when different number of meanings and values
+    flag_meanings = ["not_used", "good_data", "suspect_data"]
+    flag_values = [0, 1, 2, 3]
+    with pytest.raises(
+        ValueError,
+        match=r"Different number of flag_values \(4\) and flag_meanings \(3\).",
+    ):
+        util.change_qc_flags(
+            ncfile, "qc_var", flag_meanings=flag_meanings, flag_values=flag_values
+        )
+
+    # test works with values made when not defined
+    flag_meanings = ["not_used", "good_data", "suspect_data", "more_suspect_data"]
+    util.change_qc_flags(ncfile, "qc_var", flag_meanings=flag_meanings)
+    assert (
+        ncfile["qc_var"].getncattr("flag_meanings")
+        == "not_used good_data suspect_data more_suspect_data"
+    )
+    assert all(ncfile["qc_var"].getncattr("flag_values") == [0, 1, 2, 3])
+
+    # test works with correct meanings and values given
+    flag_meanings = [
+        "not_used",
+        "good_data",
+        "suspect_data",
+        "more_suspect_data",
+        "very_unlikely_data",
+    ]
+    flag_values = [0, 1, 2, 3, 4]
+    util.change_qc_flags(
+        ncfile, "qc_var", flag_meanings=flag_meanings, flag_values=flag_values
+    )
+    assert (
+        ncfile["qc_var"].getncattr("flag_meanings")
+        == "not_used good_data suspect_data more_suspect_data very_unlikely_data"
+    )
+    assert all(ncfile["qc_var"].getncattr("flag_values") == [0, 1, 2, 3, 4])
+
+
 def test_update_variable():
     # Create a temporary netCDF file
     with tempfile.NamedTemporaryFile(delete=False, suffix=".nc") as temp:


### PR DESCRIPTION
Adds the `util.change_qc_flags` function to allow users to define own flag_values and flag_meanings, provided they meet the NCAS-General requirements.
Also change the MacOS runner from `macos-latest` to `macos-latest-large`, avoiding the arm64 architecture (for now) - closes #139 