### PR TITLE
Wrong platform value in global attribute

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -5,6 +5,10 @@ Revision History
 ----------------
 Important changes of note with each release:
 
+2.5.1
+^^^^^
+- Fix bug in ``create_netcdf.make_netcdf`` where the ``platform`` attribute was not being added back to the FileInfo class object after being formatted, resulting in the wrong value being used by ``create_netcdf.add_attributes`` for the ``platform`` global attribute.
+
 2.5.0
 ^^^^^
 - Replaced using ``instrument_dict`` dictionary from ``tsv2dict.instrument_dict`` in various create netcdf functions with using ``FileInfo`` class from ``file_info``. This class better contains the information needed and removes the complexity of the dictionary where different levels of nesting could contain different types of data, which meant IDE plugins relying on type hints to provide information often gave unhelpful messages.

--- a/src/ncas_amof_netcdf_template/create_netcdf.py
+++ b/src/ncas_amof_netcdf_template/create_netcdf.py
@@ -721,6 +721,7 @@ def make_netcdf(
         platform = (
             instrument_file_info.instrument_data["Mobile/Fixed (loc)"].strip().lower()
         )
+    instrument_file_info.instrument_data["Mobile/Fixed (loc)"] = platform
 
     if options != "":
         no_options = len(options.split("_"))

--- a/tests/test_create_netcdf.py
+++ b/tests/test_create_netcdf.py
@@ -18,6 +18,7 @@ def test_main_process():
     assert nc["air_temperature"].size == 5
     nant.util.update_variable(nc, "air_temperature", [12.3, 14.54, 23.5, 12.4, 65.3])
     assert nc["air_temperature"].valid_min == np.float32(12.3)
+    assert nc.getncattr("platform") == "iao"
     nc.close()
     os.remove("ncas-aws-10_iao_20221117_surface-met_v1.0.nc")
 
@@ -32,6 +33,7 @@ def test_main_process():
     assert nc["air_temperature"].size == 5
     nant.util.update_variable(nc, "air_temperature", [12.3, 14.54, 23.5, 12.4, 65.3])
     assert nc["air_temperature"].valid_min == np.float32(12.3)
+    assert nc.getncattr("platform") == "somewhere-else"
     nc.close()
     os.remove("ncas-aws-10_somewhere-else_20221117_surface-met_v1.0.nc")
 


### PR DESCRIPTION
Added the formatted value (i.e. lower case, removed "fixed") of `platform` back to the `FileInfo` object, so it was available to use by the `add_attributes` function.