### PR TITLE
Add metadata from python dictionary

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
       fail-fast: false
 
     steps:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ formats:
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
+    python: "3.10"
   jobs:
     post_build:
       - mkdir -p ${READTHEDOCS_OUTPUT}/pdf

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A full description on how to install and use this module can be found [through t
 
 Requirements
 ------------
-* Python 3.9 or above
+* Python 3.10 or above
 * Python modules:
   * [netCDF4](http://unidata.github.io/netcdf4-python/)
   * [NumPy](https://numpy.org/)

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -155,7 +155,13 @@ Metadata
 --------
 While all required metadata fields are added to the global attributes of the netCDF file, and in some cases the defined values are directly inserted, it is necessary to add further metadata values to the netCDF file, for example ``creator_name``. Fields that need metadata adding to them are initially given placeholder text which starts with the word "CHANGE" - simple interrogation of the created netCDF file will reveal which attributes need specifying.
 
-The contents of a CSV file containing metadata can then be added to the netCDF file
+Metadata can be added to the data file either from a dedicated file or from a python dictionary.
+
+
+Metadata File
+^^^^^^^^^^^^^
+
+The contents of a file containing metadata can then be added to the netCDF file
 
 .. code-block:: python
 
@@ -165,13 +171,24 @@ Metadata can be supplied in CSV, JSON, YAML or XML formats; see the `metadata fo
 
 .. code-block:: python
 
-   nant.util.add_metadata_to_netcdf(nc, 'metadata_file', file_format = 'csv')
+   nant.util.add_metadata_to_netcdf(nc, 'metadata_file', file_format = 'CSV')
 
 If detection fails and ``file_format`` is not given, the function will attempt to read the file as a CSV.
 
 One additional parameters can be supplied in the metadata file with each individual attributes:
 
 - ``type`` - what data type the value of the attribute should take, e.g. ``integer`` or ``string``. Default if absent is ``string``.
+
+
+Metadata Dictionary
+^^^^^^^^^^^^^^^^^^^
+
+A dictionary containing metadata can be used to add to the netCDF file
+
+.. code-block:: python
+
+   metadata_dict = {"creator_name": "A.Person", "title": "Data from the instrument"}
+   nant.util.add_metadata_from_dict(nc, metadata_dict)
 
 
 Latitude, Longitude, and Geospatial Bounds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 description = "Package to create NCAS AMOF netCDF files."
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.9, <4"
+requires-python = ">=3.10, <4"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
@@ -21,11 +21,11 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries :: Python Modules"

--- a/src/ncas_amof_netcdf_template/create_netcdf.py
+++ b/src/ncas_amof_netcdf_template/create_netcdf.py
@@ -788,7 +788,6 @@ def make_product_netcdf(
     date: Optional[str] = None,
     dimension_lengths: dict[str, int] = {},
     platform: str = "",
-    instrument_loc: str = "",
     deployment_loc: str = "land",
     verbose: int = 0,
     options: str = "",
@@ -814,8 +813,6 @@ def make_product_netcdf(
                                   for needed dimension, user will be asked to type
                                   in dimension length
         platform (str): observatory or location of the instrument. Default "".
-        instrument_loc (str): [DEPRECATED - use "platform" instead] observatory or
-                              location of the instrument. Default "".
         deployment_loc (str): one of 'land', 'sea', 'air', 'trajectory'.
                               Default "land".
         verbose (int): level of info to print out. Note that at the moment there is
@@ -849,23 +846,6 @@ def make_product_netcdf(
         netCDF file object or nothing.
     """
     chunk_by_dimension = chunk_by_dimension or {}
-
-    if platform != "" and instrument_loc != "":
-        warnings.warn(
-            "Both platform and instrument_loc are given, using platform."
-            " instrument_loc will be removed from version 2.6.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-    if instrument_loc != "":
-        warnings.warn(
-            "instrument_loc is deprecated, use platform instead."
-            " This option will be removed from version 2.6.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        platform = instrument_loc
 
     if date is None:
         date = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%d")

--- a/src/ncas_amof_netcdf_template/tsv2dict.py
+++ b/src/ncas_amof_netcdf_template/tsv2dict.py
@@ -319,7 +319,6 @@ def instrument_dict(
 def product_dict(
     desired_product: str,
     platform: str = "",
-    instrument_loc: str = "",
     deployment_loc: str = "land",
     use_local_files: Optional[str] = None,
     tag: str = "latest",
@@ -344,23 +343,6 @@ def product_dict(
         dictionary of all attributes, dimensions and variables
         associated with the named data product.
     """
-    if platform != "" and instrument_loc != "":
-        warnings.warn(
-            "Both platform and instrument_loc are used, using platform."
-            " instrument_loc will be removed from version 2.6.0",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-    if instrument_loc != "":
-        warnings.warn(
-            "instrument_loc is deprecated, use platform instead"
-            " This option will be removed from version 2.6.0",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        platform = instrument_loc
-
     common_dimensions_url = values.get_common_dimensions_url(
         use_local_files=use_local_files, tag=tag, loc=deployment_loc
     )

--- a/src/ncas_amof_netcdf_template/util.py
+++ b/src/ncas_amof_netcdf_template/util.py
@@ -300,6 +300,16 @@ def add_metadata_to_netcdf(
                 ncfile.setncattr(attr, value)
 
 
+def add_metadata_from_dict(
+    ncfile: Dataset, metadata_dict: dict[str, str | int | float]
+) -> None:
+    for key, value in metadata_dict.items():
+        if key in ["latitude", "longitude"]:
+            update_variable(ncfile, key, value)
+        else:
+            ncfile.setncattr(key, value)
+
+
 def get_times(
     dt_times: list[dt.datetime],
 ) -> tuple[

--- a/src/ncas_amof_netcdf_template/util.py
+++ b/src/ncas_amof_netcdf_template/util.py
@@ -230,7 +230,9 @@ def read_xml_metadata(metafile: str) -> dict[str, dict[str, Union[str, type]]]:
     return raw_metadata
 
 
-def get_metadata(metafile: str) -> dict[str, dict[str, Union[str, type]]]:
+def get_metadata(
+    metafile: str, file_format: Optional[str] = None
+) -> dict[str, dict[str, Union[str, type]]]:
     """
     Returns a dict from of metadata from file. Metadata can be in a CSV, JSON, YAML, or XML file.
     Can also include latitude and longitude variables if
@@ -238,17 +240,22 @@ def get_metadata(metafile: str) -> dict[str, dict[str, Union[str, type]]]:
 
     Args:
         metafile (file): file with metadata
+        file_format (str): format of metadata file. One of 'CSV', 'JSON',
+          'YAML', or 'XML' if given. Default is None, which means the function
+          will attempt to detect file type.
 
     Returns:
         dict: metadata as dictionary
     """
-    if metafile.endswith(".csv"):
+    if metafile.endswith(".csv") or file_format == "CSV":
         return read_csv_metadata(metafile)
-    elif metafile.endswith(".json"):
+    elif metafile.endswith(".json") or file_format == "JSON":
         return read_json_metadata(metafile)
-    elif metafile.endswith(".yaml") or metafile.endswith(".yml"):
+    elif (
+        metafile.endswith(".yaml") or metafile.endswith(".yml") or file_format == "YAML"
+    ):
         return read_yaml_metadata(metafile)
-    elif metafile.endswith(".xml"):
+    elif metafile.endswith(".xml") or file_format == "XML":
         return read_xml_metadata(metafile)
     else:
         warnings.warn(
@@ -258,7 +265,9 @@ def get_metadata(metafile: str) -> dict[str, dict[str, Union[str, type]]]:
 
 
 def add_metadata_to_netcdf(
-    ncfile: Dataset, metadata_file: Optional[str] = None
+    ncfile: Dataset,
+    metadata_file: Optional[str] = None,
+    file_format: Optional[str] = None,
 ) -> None:
     """
     Reads metadata from csv file using get_metadata, adds values to
@@ -270,10 +279,13 @@ def add_metadata_to_netcdf(
 
     Args:
         ncfile (netCDF Dataset): Dataset object of netCDF file.
-        metadata_file (file): csv file with metadata, one attribute per line
+        metadata_file (str): file with metadata, one attribute per line.
+        file_format (str): format of metadata file. One of 'CSV', 'JSON',
+          'YAML', or 'XML' if given. Default is None, which means the function
+          will attempt to detect file type.
     """
     if metadata_file is not None:
-        raw_metadata = get_metadata(metadata_file)
+        raw_metadata = get_metadata(metadata_file, file_format)
         for attr, attr_info in raw_metadata.items():
             value = attr_info["value"]
             # append_value = attr_info["append"]
@@ -303,6 +315,15 @@ def add_metadata_to_netcdf(
 def add_metadata_from_dict(
     ncfile: Dataset, metadata_dict: dict[str, str | int | float]
 ) -> None:
+    """
+    Take metadata from dictionary and add to global attributes in netCDF file.
+    Can also include latitude and longitude variables if they are
+    single values (e.g. point deployment), using update_variable function.
+
+    Args:
+        ncfile (netCDF Dataset): Dataset object of netCDF file.
+        metadata_dict (dict): Dictionary of attribute name/value pairs.
+    """
     for key, value in metadata_dict.items():
         if key in ["latitude", "longitude"]:
             update_variable(ncfile, key, value)

--- a/tests/test_create_netcdf.py
+++ b/tests/test_create_netcdf.py
@@ -504,25 +504,6 @@ def test_list_products(instrument, products):
 
 
 def test_make_product_netcdf():
-    # Test with return_open=False and using instrument_loc
-    nc = nant.create_netcdf.make_product_netcdf(
-        "product1",
-        "instrument1",
-        date="20221117",
-        dimension_lengths={"time": 5},
-        instrument_loc="location1",
-        deployment_loc="land",
-        verbose=0,
-        options="",
-        product_version="1.0",
-        file_location=".",
-        use_local_files=None,
-        tag="latest",
-    )
-    assert os.path.exists("instrument1_location1_20221117_product1_v1.0.nc")
-    nc.close()
-
-    # Test with platform instead of instrument_loc
     nc = nant.create_netcdf.make_product_netcdf(
         "product1",
         "instrument1",

--- a/tests/test_metadata_files/test_json.metadata
+++ b/tests/test_metadata_files/test_json.metadata
@@ -1,0 +1,19 @@
+{
+    "key1": "value1",
+    "key2": {
+        "value": "value2"
+    },
+    "key3": {
+        "value": 12,
+        "type": "int"
+    },
+    "key4": 12,
+    "key5": {
+        "value": 12,
+        "type": "int"
+    },
+    "latitude": {
+        "value": 12.34
+    },
+    "longitude": 56.78
+}

--- a/tests/test_tsv2dict.py
+++ b/tests/test_tsv2dict.py
@@ -304,21 +304,6 @@ def test_product_dict_with_local_files():
     assert "info" in result
     assert result["info"]["Mobile/Fixed (loc)"] == "loc1"
 
-    # Make sure we get the same if still using deprecated "instrument_loc" argument instead of "platform"
-    result = tsv2dict.product_dict(
-        "product1",
-        instrument_loc="loc1",
-        deployment_loc="land",
-        use_local_files="/local/path",
-        tag="tag1",
-    )
-
-    # Check the result
-    assert "common" in result
-    assert "product1" in result
-    assert "info" in result
-    assert result["info"]["Mobile/Fixed (loc)"] == "loc1"
-
 
 def test_product_dict():
     # Mock the get_common_dimensions_url, get_common_variables_url, get_common_attributes_url,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -31,6 +31,7 @@ def test_check_type_convert():
     assert not util.check_type_convert("one", float)
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_get_metadata():
     # Create a temporary CSV file
     with tempfile.NamedTemporaryFile(delete=False, mode="w", newline="") as temp:
@@ -73,18 +74,22 @@ def test_get_metadata_different_formats():
     csv_file = "tests/test_metadata_files/test_csv.csv"
     yaml_file = "tests/test_metadata_files/test_yaml.yaml"
     json_file = "tests/test_metadata_files/test_json.json"
+    json_file_bad_ext = "tests/test_metadata_files/test_json.metadata"
     xml_file = "tests/test_metadata_files/test_xml.xml"
 
     csv_result = util.get_metadata(csv_file)
     yaml_result = util.get_metadata(yaml_file)
     json_result = util.get_metadata(json_file)
+    json_bad_ext_result = util.get_metadata(json_file_bad_ext, file_format="JSON")
     xml_result = util.get_metadata(xml_file)
 
     assert csv_result == yaml_result
     assert yaml_result == json_result
-    assert json_result == xml_result
+    assert json_result == json_bad_ext_result
+    assert json_bad_ext_result == xml_result
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_get_metadata_with_empty_file():
     # Create a temporary CSV file
     with tempfile.NamedTemporaryFile(delete=False, mode="w", newline="") as temp:
@@ -150,6 +155,51 @@ def test_add_metadata_to_netcdf():
     # Delete the temporary netCDF file and the temporary CSV file
     os.remove(temp_path)
     # os.remove(metadata_path)
+
+
+def test_add_metadata_from_dict():
+    # Create a temporary netCDF file
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".nc") as temp:
+        ncfile = Dataset(temp.name, "w", format="NETCDF4_CLASSIC")
+        ncfile.createDimension("dim", None)
+        ncfile.createVariable("latitude", "f4", ("dim",))
+        ncfile.createVariable("longitude", "f4", ("dim",))
+        ncfile.key1 = "old_value1"
+        ncfile.key3 = "old_value3"
+        ncfile.key4 = "old_value4"
+        temp_path = temp.name
+
+    metadata_dict = {
+        "key1": "value1",
+        "key2": "value2",
+        "key3": 12,
+        "key4": "12",
+        "latitude": 12.34,
+        "longitude": 56.78,
+    }
+
+    # Call the add_metadata_to_netcdf function with the temporary netCDF file and the temporary CSV file
+    util.add_metadata_from_dict(ncfile, metadata_dict)
+
+    # Check the result
+    # overwrite existing
+    assert ncfile.getncattr("key1") == "value1"
+    # "key2" should be added
+    assert ncfile.getncattr("key2") == "value2"
+    # appending doesnt work with netcdf4_classic
+    ## appended value will only ever be a string
+    # assert ncfile.getncattr("key3") == ["old_value3", "12"]
+    assert ncfile.getncattr("key3") == 12
+    # string number in csv is tidy string in netCDF
+    assert ncfile.getncattr("key4") == "12"
+    # latitude and longitude are added as variables
+    assert np.allclose(ncfile.variables["latitude"][:], 12.34)
+    assert np.allclose(ncfile.variables["longitude"][:], 56.78)
+
+    ncfile.close()
+
+    # Delete the temporary netCDF file and the temporary CSV file
+    os.remove(temp_path)
 
 
 def test_get_times():


### PR DESCRIPTION
Allow adding metadata straight from a python dictionary, rather than only from a separate metadata file.
This also adds the `file_format` argument to the `add_metadata_to_netcdf` function that was mentioned in the documentation but wasn't in the code.
Update minimum python from 3.9 to 3.10 as 3.9 is no longer supported.
Remove `instrument_loc` argument as per the deprecation policy.